### PR TITLE
Bump python version to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p /home/jovyan/.jupyter/custom
 
 ADD util/theme-superhero-datascience/custom.css /home/jovyan/.jupyter/custom/
 
-RUN cd $CONDA_DIR/lib/python3.6/site-packages/paretochart && \
+RUN cd $CONDA_DIR/lib/python3.9/site-packages/paretochart && \
     2to3 -w *.py
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook:hub-2.2.1
 
 LABEL maintainer "Dario Malchiodi <malchiodi@di.unimi.it>"
 


### PR DESCRIPTION
Nel `Dockerfile` si assumeva che ci fosse python 3.6, questo non è più vero. Ora l'immagine di base usa py3.9, con questo commit non si rompe durante la fase di build su servizi come `Binder`