### PR TITLE
Correzione errori L03

### DIFF
--- a/content/L03-Dati_e_frequenze.ipynb
+++ b/content/L03-Dati_e_frequenze.ipynb
@@ -334,7 +334,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Abs. freqence</th>\n",
+       "      <th>Abs. frequence</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Publisher</th>\n",
@@ -387,7 +387,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                   Abs. freqence\n",
+       "                   Abs. frequence\n",
        "Publisher                       \n",
        "ABC Studios                    4\n",
        "DC Comics                    121\n",
@@ -408,7 +408,7 @@
    ],
    "source": [
     "publisher_freq = pd.crosstab(index=heroes_with_year['Publisher'],\n",
-    "                             columns=['Abs. freqence'],\n",
+    "                             columns=['Abs. frequence'],\n",
     "                             colnames=[''])\n",
     "publisher_freq"
    ]
@@ -450,7 +450,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Rel. freqence</th>\n",
+       "      <th>Rel. frequence</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Publisher</th>\n",
@@ -503,7 +503,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                   Rel. freqence\n",
+       "                   Rel. frequence\n",
        "Publisher                       \n",
        "ABC Studios             0.011111\n",
        "DC Comics               0.336111\n",
@@ -524,7 +524,7 @@
    ],
    "source": [
     "publisher_abs_freq = pd.crosstab(index=heroes_with_year['Publisher'],\n",
-    "                                 columns=['Rel. freqence'],\n",
+    "                                 columns=['Rel. frequence'],\n",
     "                                 colnames=[''])\n",
     "publisher_rel_freq = publisher_abs_freq / publisher_abs_freq.sum()\n",
     "\n",
@@ -564,7 +564,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Rel. freqence</th>\n",
+       "      <th>Rel. frequence</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Publisher</th>\n",
@@ -617,7 +617,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                   Rel. freqence\n",
+       "                   Rel. frequence\n",
        "Publisher                       \n",
        "ABC Studios             0.011111\n",
        "DC Comics               0.336111\n",
@@ -638,7 +638,7 @@
    ],
    "source": [
     "publisher_rel_freq = pd.crosstab(index=heroes_with_year['Publisher'],\n",
-    "                                 columns=['Rel. freqence'],\n",
+    "                                 columns=['Rel. frequence'],\n",
     "                                 colnames=[''],\n",
     "                                 normalize=True)\n",
     "publisher_rel_freq"
@@ -677,7 +677,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Rel. freqence</th>\n",
+       "      <th>Rel. frequence</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Publisher</th>\n",
@@ -730,7 +730,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                   Rel. freqence\n",
+       "                   Rel. frequence\n",
        "Publisher                       \n",
        "ABC Studios                  1.1\n",
        "DC Comics                   33.6\n",
@@ -786,7 +786,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Rel. freqence</th>\n",
+       "      <th>Rel. frequence</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Publisher</th>\n",
@@ -839,7 +839,7 @@
        "</div>"
       ],
       "text/plain": [
-       "                  Rel. freqence\n",
+       "                  Rel. frequence\n",
        "Publisher                      \n",
        "ABC Studios               1.11%\n",
        "DC Comics                33.61%\n",
@@ -1189,14 +1189,14 @@
    "source": [
     "male_strength_freq = (pd.crosstab(index=heroes.loc[heroes['Gender']=='M',\n",
     "                                                   'Strength'],\n",
-    "                                 columns='Abs. freq.',\n",
+    "                                 columns='Rel. freq.',\n",
     "                                 normalize=True)\n",
-    "                        .loc[:, 'Abs. freq.'])\n",
+    "                        .loc[:, 'Rel. freq.'])\n",
     "female_strength_freq = (pd.crosstab(index=heroes.loc[heroes['Gender']=='F',\n",
     "                                                     'Strength'],\n",
-    "                                   columns='Abs. freq.',\n",
+    "                                   columns='Rel. freq.',\n",
     "                                   normalize=True)\n",
-    "                          .loc[:, 'Abs. freq.'])\n",
+    "                          .loc[:, 'Rel. freq.'])\n",
     "\n",
     "male_strength_freq.plot(marker='o', color='blue', legend=False)\n",
     "female_strength_freq.plot(marker='o', color='pink', legend=False)\n",


### PR DESCRIPTION
Come da accordi, questa patch corregge i typo fatti notare alla lezione odierna. Più precisamente:
- modifica del nome della colonna da `Abs. freq` a `Rel. freq` nella cella [15];
- modifica di tutte le occorrenze di _freqence_ in _frequence_.