### PR TITLE
Aggiunto requirements.txt e utilizzo del fork di paretochart per Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN jupyter nbextension enable hide_input/main
 
 RUN python -m ipykernel install
 
-RUN pip install --upgrade paretochart
-
-
+# Install additional requirements (if not already installed)
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 
 USER jovyan
 
@@ -61,10 +61,5 @@ RUN chgrp users /home/jovyan/L*ipynb
 RUN mkdir -p /home/jovyan/.jupyter/custom
 
 ADD util/theme-superhero-datascience/custom.css /home/jovyan/.jupyter/custom/
-
-RUN cd $CONDA_DIR/lib/python3.9/site-packages/paretochart && \
-    2to3 -w *.py
-
-
 
 USER jovyan

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN python -m ipykernel install
 # Install additional requirements (if not already installed)
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN rm requirements.txt
 
 USER jovyan
 

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -13,6 +13,7 @@ USER root
 # Install additional requirements (if not already installed)
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN rm requirements.txt
 
 USER $NB_UID
 

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -10,9 +10,9 @@ RUN conda update conda && conda install -c conda-forge --yes \
  ipyvolume
 
 USER root
-RUN pip install --upgrade paretochart && \
-    cd $CONDA_DIR/lib/python3.6/site-packages/paretochart && \
-    2to3 -w *.py
+# Install additional requirements (if not already installed)
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 
 USER $NB_UID
 

--- a/content/L03-Dati_e_frequenze.ipynb
+++ b/content/L03-Dati_e_frequenze.ipynb
@@ -2229,11 +2229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Bisogna sottolineare che il package `paretochart` è, al momento, non ancora stato portato alla versione 3 di python. Quindi dopo la sua installazione, da effettuarsi preferibilmente tramite `pip` (il package non è attualmente disponibile in anaconda), è necessario eseguire lo script\n",
-    "\n",
-    "   $ 2to3 -w *.py\n",
-    "   \n",
-    "nella directory in cui è stato installato il package (tipicamente, la directory `site-packages/paretochart` all'interno della directory in cui risultano installate le librerie di python)."
+    "Bisogna sottolineare che il package `paretochart` è, al momento, non ancora stato portato alla versione 3 di python. La community ha però provveduto creando una _fork_ chiamata `rogeriopradoj-paretochart` installabile tramite `pip`."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+jupyter
+numpy
+pandas
+matplotlib
+graphviz
+scipy
+sklearn
+rogeriopradoj-paretochart
+statsmodels
+ipywidgets
+


### PR DESCRIPTION
- Aggiunto il file `requirements.txt` con tutte le dipendenze PyPi di tutti i notebook, anche se alcune erano già incluse dall'immagine Docker originale
- Utilizzo della fork `rogeriopradoj-paretochart` (nativamente compatbile con Python 3) al posto di `paretochart`
- Adattate le istruzioni nella L03 con nuove istruzioni per l'installazione di paretochart