### PR TITLE
Risolta dipendenza deprecata e corretto un typo

### DIFF
--- a/content/L01-Introduzione_a_python.ipynb
+++ b/content/L01-Introduzione_a_python.ipynb
@@ -890,7 +890,7 @@
     "<div id=\"h-6\"></div>\n",
     "\n",
     "### Gli insiemi\n",
-    "Python implementa direttamente un tipo di dato per gli insiemi, intesi come collezione finita di elementi tra loro distinguibili e non memorizzati in un ordine particolare. A differenza delle liste e delle tuple, gli elementi non sono quindi associati a una posizione e non è possibile che un insieme contenga più di un'istanza di un medesimo elemento. Non utilizzeremo questo tipo di dato, quindi si rimanda alla [documentazione ufficiale](https://docs.python.org/2/library/stdtypes.html#set) per un approfondimento."
+    "Python implementa direttamente un tipo di dato per gli insiemi, intesi come collezione finita di elementi tra loro distinguibili e non memorizzati in un ordine particolare. A differenza delle liste e delle tuple, gli elementi non sono quindi associati a una posizione e non è possibile che un insieme contenga più di un'istanza di un medesimo elemento. Non utilizzeremo questo tipo di dato, quindi si rimanda alla [documentazione ufficiale](https://docs.python.org/3/library/stdtypes.html#set) per un approfondimento."
    ]
   },
   {

--- a/content/Untitled.ipynb
+++ b/content/Untitled.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 2
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas
 matplotlib
 graphviz
 scipy
-sklearn
+scikit-learn
 rogeriopradoj-paretochart
 statsmodels
 ipywidgets


### PR DESCRIPTION
- Modificato requirement ``` sklearn ``` (deprecato) con ```scikit-learn```
- Corretto link alla documentazione ufficiale (python2 -> python3)
- Rimosso file vuoto (vecchio leftover della migrazione da gitlab)